### PR TITLE
Remove sbt alias

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -151,7 +151,7 @@ fi
 export HISTTIMEFORMAT="%Y-%m-%d %T "
 export CLICOLOR=1  # in macOS, equivalent to: ls -G
 export LEIN_SUPPRESS_USER_LEVEL_REPO_WARNINGS=true
-alias sbt="TERM=xterm-color sbt -Dscala.color"
+
 # References:
 # - https://github.com/sbt/sbt/issues/3240#issuecomment-306421046 (enables autocomplete and navigation with arrows)
 # - https://stackoverflow.com/a/33832205/7649076 (color in the REPL)


### PR DESCRIPTION
```shell
$ /usr/local/bin/sbt console
[warn] No sbt.version set in project/build.properties, base directory: /Users/guilherme/dev/gcbeltramini/dotfiles
[info] Loading settings for project global-plugins from idea.sbt ...
[info] Loading global plugins from /Users/guilherme/.sbt/1.0/plugins
[info] Set current project to dotfiles (in build file:/Users/guilherme/dev/gcbeltramini/dotfiles/)
[info] Starting scala interpreter...
Welcome to Scala 2.12.10 (OpenJDK 64-Bit Server VM, Java 1.8.0_232).
Type in expressions for evaluation. Or try :help.
```
![Screen Shot 2019-11-06 at 15 46 39](https://user-images.githubusercontent.com/9801748/68327745-b1779300-00ac-11ea-97fe-ba01b28d280d.png)

```shell
$ TERM=xterm-color /usr/local/bin/sbt -Dscala.color console
(... same output ...)
```
![Screen Shot 2019-11-06 at 15 46 46](https://user-images.githubusercontent.com/9801748/68327766-b9cfce00-00ac-11ea-9c15-882c3b47c177.png)

`$ scala` and `$ scala -Dscala.color` result in the same as above (but with `scala>` in colors). [Ammonite](https://ammonite.io/) is a better REPL.

Ref.:
[1] https://alvinalexander.com/photos/using-color-scala-repl