### PR TITLE
Update all

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -257,7 +257,6 @@ if is_valid_command brew; then
 
 fi
 
-source_if_exists "${NUCLI_HOME}/nu.bashcompletion"
 
 
 # Utilities

--- a/.custom/utils
+++ b/.custom/utils
@@ -50,6 +50,25 @@ conda-update-all() {
   conda clean --all --yes
 }
 
+npm-update-all() {
+  npm update -g
+}
+
+update-all() {
+  echo "Homebrew"
+  brew-update-all
+  echo "Done!"
+  echo "conda"
+  conda-update-all
+  echo "Done!"
+  echo "n"
+  sudo n latest
+  echo "Done!"
+  echo "npm"
+  npm-update-all
+  echo "Done!"
+}
+
 ll() {
   local path="${1:-$(pwd)}"
   # `ls` must be GNU-ls. In MacOS, `ls` will be `gls`: $ brew install coreutils

--- a/.custom/utils
+++ b/.custom/utils
@@ -35,13 +35,12 @@ cdh() {
 brew-update-all() {
   brew update
   brew upgrade
-  brew cask upgrade
   brew cleanup -s
 
   echo -e "\n\033[34mInstalled Casks that have newer versions available in the tap,"
   echo -e "including the Casks that have \`auto_updates true\` or \`version :latest\`:\033[0m"
-  brew cask outdated --greedy
-  echo -e "\n\033[34mTo install them, run \`brew cask upgrade <program-name>\`.\033[0m"
+  brew outdated --cask --greedy
+  echo -e "\n\033[34mTo install them, run \`brew upgrade <program-name>\`.\033[0m"
 
 }
 


### PR DESCRIPTION
- Update brew cask command. Now `brew upgrade` will upgrade everything, including casks.
  ```bash
  $ brew cask upgrade
  Warning: Calling brew cask upgrade is deprecated! Use brew upgrade --cask instead.

  $ brew upgrade --help
  (...)
        --cask                       Only upgrade outdated casks.
  (...)
  ```
- Add function to update all